### PR TITLE
Add schema.org itemtype mapping for publications

### DIFF
--- a/src/lib/cv/Publication.svelte
+++ b/src/lib/cv/Publication.svelte
@@ -188,14 +188,36 @@
 
 
 
+  const schemaItemTypeByCSL: Record<string, string> = {
+    'article': 'ScholarlyArticle',
+    'article-journal': 'ScholarlyArticle',
+    'article-magazine': 'Article',
+    'article-newspaper': 'NewsArticle',
+    'book': 'Book',
+    'chapter': 'Chapter',
+    'dataset': 'Dataset',
+    'manuscript': 'Manuscript',
+    'paper-conference': 'ScholarlyArticle',
+    'post': 'BlogPosting',
+    'report': 'Report',
+    'thesis': 'Thesis',
+    'webpage': 'WebPage'
+  };
+
+  const defaultItemType = 'ScholarlyArticle';
+
+  function resolveItemType(publication: CSLPublication | undefined): string {
+    if (!publication?.type) return defaultItemType;
+    return schemaItemTypeByCSL[publication.type] ?? defaultItemType;
+  }
+
+  $: publicationItemType = `http://schema.org/${resolveItemType(data)}`;
+
   let showAbstract = false;
 
 </script>
-<!---
-TODO allow customizing the itemtype
--->
 <div class="text-sm publication flex-auto w-80 dark:bg-slate-700 bg-slate-200 m-2 rounded-lg p-5" itemscope
-  itemtype="http://schema.org/ScholarlyArticle">
+  itemtype={publicationItemType}>
   <div class="flex items-start">
   <h2 class="text-lg" itemprop="headline">
       {data?.title || 'Untitled'}


### PR DESCRIPTION
### Motivation
- Improve semantic markup by mapping CSL publication `type` values to appropriate `schema.org` itemtype values for each publication card.
- Allow the publication card to expose a dynamic itemtype so different publication kinds (e.g., books, preprints, journal articles) are represented correctly in structured data.
- Provide a sensible default (`ScholarlyArticle`) when a CSL type is missing or unmapped.

### Description
- Added a `schemaItemTypeByCSL` mapping object that maps CSL `type` strings to `schema.org` item types.
- Implemented `resolveItemType(publication)` and a reactive `publicationItemType` (`$: publicationItemType = ...`) that derives the full `http://schema.org/...` itemtype for the current `data` prop.
- Replaced the hard-coded `itemtype=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972edfe3b688321b9c04940855bd915)